### PR TITLE
Fix MacOS temporary path errors.

### DIFF
--- a/yaraburp.py
+++ b/yaraburp.py
@@ -297,6 +297,8 @@ class BurpExtender(IBurpExtender, ITab, IMessageEditorController, IContextMenuFa
             temp_folder = "/tmp"
         elif "windows" in os_name:
             temp_folder = os.environ.get("TEMP")
+        elif "posix" in os_name:
+            temp_folder = "/tmp"
             if temp_folder is None:
                 temp_folder = os.environ.get("TMP")
 


### PR DESCRIPTION
On MacOS the yara burp extension is unable to detect and set the temp path which results in the error "Could not determine TEMP folder location." in the extensions error screen when initiating a Yara scan.